### PR TITLE
(MAINT) Fix GitHub Actions

### DIFF
--- a/.github/workflows/hugo-module-deps.yml
+++ b/.github/workflows/hugo-module-deps.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   update_hugo_modules:
-    runs-on: windows-2019
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Update Hugo Modules

--- a/.github/workflows/hugo-netlify-version.yml
+++ b/.github/workflows/hugo-netlify-version.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   update_hugo_modules:
-    runs-on: windows-2019
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Update Hugo Version for Netlify


### PR DESCRIPTION
This change switches the OS for the GitHub Actions to run on Ubuntu as a workaround for an unfixed bug in an upstream dependency of the action preventing Hugo from being installed on non-Linux platforms.