### PR TITLE
(MAINT) Hide title in mobile

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -523,6 +523,9 @@ body[dir='rtl'] .book-menu input.toggle:checked + label::after {
   }
   .book-header {
     display: block;
+    div > strong {
+      display: none;
+    }
   }
   #menu-control:focus ~ main label[for='menu-control'] {
     outline-style: auto;


### PR DESCRIPTION
This change overrides the default styling to hide the strong element in the page header even in mobile view.